### PR TITLE
Implement email sending endpoint for registration flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,14 @@
         <java.version>1.8</java.version>
     </properties>
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.springframework.boot</groupId>-->
+<!--            <artifactId>spring-boot-starter-data-jpa</artifactId>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.springframework.boot</groupId>-->
+<!--            <artifactId>spring-boot-starter-security</artifactId>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -114,6 +114,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+            <version>3.1.8</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/beaconfire/email/controller/EmailController.java
+++ b/src/main/java/org/beaconfire/email/controller/EmailController.java
@@ -1,0 +1,27 @@
+package org.beaconfire.email.controller;
+
+import org.beaconfire.email.service.EmailService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/emails")
+public class EmailController {
+    private final EmailService emailService;
+
+    public EmailController(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @PostMapping("/registration")
+    public ResponseEntity<?> sendRegistrationEmail(
+            @RequestParam String email,
+            @RequestParam String registrationLink
+    ) {
+        emailService.sendRegistrationEmail(email, registrationLink);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/beaconfire/email/service/EmailService.java
+++ b/src/main/java/org/beaconfire/email/service/EmailService.java
@@ -1,0 +1,10 @@
+package org.beaconfire.email.service;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+
+public interface EmailService {
+    @PostMapping("/emails/registration")
+    void sendRegistrationEmail(@RequestParam String email, @RequestParam String registrationLink);
+}

--- a/src/main/java/org/beaconfire/email/service/EmailServiceImpl.java
+++ b/src/main/java/org/beaconfire/email/service/EmailServiceImpl.java
@@ -1,0 +1,15 @@
+package org.beaconfire.email.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailServiceImpl implements EmailService {
+    @Override
+    // Just for testing now
+    // Will implement email sending in the future
+    public void sendRegistrationEmail(String email, String registrationLink) {
+        System.out.println("===Sending Email===");
+        System.out.println("To Email: " + email);
+        System.out.println("Registration Link: " + registrationLink);
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,6 +1,6 @@
 spring.application.name=authentication
 # Server Port
-server.port=8082
+server.port=8083
 logging.level.org.springframework=DEBUG
 # MySQL Database Configuration
 spring.datasource.url=jdbc:mysql://localhost:3306/AuthenticationService?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,16 @@
 spring.application.name=authentication
 # Server Port
-server.port=8082
-# MySQL Database Configuration
-spring.datasource.url=${SPRING_DATASOURCE_URL}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-# JPA/Hibernate Configuration
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+server.port=8083
+## MySQL Database Configuration
+#spring.datasource.url=${SPRING_DATASOURCE_URL}
+#spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+#spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+## JPA/Hibernate Configuration
+#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+#spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.show-sql=true
+#spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 # JWT Properties
 app.jwt.secret=NiXTYNwyutkwyp34w3TYjb297yYUZCaCmr3YhDdT0W4=
 app.jwt.expiration-in-ms=86400000


### PR DESCRIPTION
- For now, email service supports integration with Employee Service via Feign Client and will just log email and link to console to simulate sending the registration email. 
- The sending to email function will be implemented later.
- Commented out unused dependencies (e.g. JPA, Security) to avoid errors during testing.

